### PR TITLE
fix mapping for smallint

### DIFF
--- a/src/linqpad-entity-factory.linq
+++ b/src/linqpad-entity-factory.linq
@@ -688,7 +688,7 @@ public static class Shared
 		,{ "money", "decimal" }
 		,{ "numeric", "decimal" }
 		,{ "nvarchar", "string" }
-		,{ "smallint", "small" }
+		,{ "smallint", "short" }
 		,{ "time", "TimeSpan" }
 		,{ "uniqueidentifier", "Guid" }
 		,{ "varbinary", "byte[]" }


### PR DESCRIPTION
The SQL data type `smallint` should be mapped to the .net data type `short`.  (`small` isn't a valid .net data type)